### PR TITLE
Update EDDN links to current versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           </div>
 
           <div class="member" style="color:#00af00;">
-            <a href="https://github.com/EDSM-NET/EDDN/wiki" target="_blank">
+            <a href="https://github.com/EDCD/EDDN/wiki" target="_blank">
               <img style="vertical-align:middle" src="images/eddn-logo.png" width="58">
               <span style="vertical-align:middle">Elite Dangerous Data Network</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         <ul>
           <li>CMDRs Guide: <a href="cmdrs-guide.html">GO</a> - The simplest guide for all CMDRs to contribute data.</li>
           <li>Frontier IDs: <a href="https://github.com/EDCD/FDevIDs">github.com/EDCD/FDevIDs</a> - A collection of IDs and Symbols used by Frontiers API or Journal.</li>
-          <li>EDDN How-to: <a href="https://github.com/EDSM-NET/EDDN/wiki#app-developers-data-uploaders">github.com/EDSM-NET/EDDN/wiki</a> - Information about how to send or receive EDDN messages.</li>
+          <li>EDDN How-to: <a href="https://github.com/EDCD/EDDN/blob/live/README.md#using-eddn">https://github.com/EDCD/EDDN/blob/live/README.md#using-eddn</a> - Information about how to send or receive EDDN messages.</li>
         </ul>
 
         <h3>Contact</h3>


### PR DESCRIPTION
1. No need to go via the old EDSM-NET org redirect.
2. The documentation has changed, so point to the preferred new URL.